### PR TITLE
Use right environemnt variable

### DIFF
--- a/UE_4.27/BuildPlugin_4-27.bat
+++ b/UE_4.27/BuildPlugin_4-27.bat
@@ -1,7 +1,6 @@
 :: Set or replace UNREAL_ENGINE_427 to
 :: the location of your 4.27 installation.
-:: AYON_ROOT (formely OPENPYPE_ROOT) should point
-:: to AYON Desktop (OpenPype) sources.
+:: AYON_UNREAL_ROOT should point to unreal addon root
 
 SET UNREAL_ENGINE_427=%PROGRAMFILES%\Epic Games\UE_4.27
-%UNREAL_ENGINE_427%\Engine\Build\BatchFiles\RunUAT.bat BuildPlugin -plugin=%AYON_ROOT%\openpype\hosts\unreal\integration\UE_4.27\Ayon\Ayon.uplugin" -Package="%~dp0..\build\UE_4.27\Ayon"
+%UNREAL_ENGINE_427%\Engine\Build\BatchFiles\RunUAT.bat BuildPlugin -plugin=%AYON_UNREAL_ROOT%\integration\UE_4.27\Ayon\Ayon.uplugin" -Package="%~dp0..\build\UE_4.27\Ayon"

--- a/UE_5.0/BuildPlugin_5-0.bat
+++ b/UE_5.0/BuildPlugin_5-0.bat
@@ -1,7 +1,6 @@
 :: Set or replace UNREAL_ENGINE_50 to
 :: the location of your 5.0 installation.
-:: AYON_ROOT (formely OPENPYPE_ROOT) should point
-:: to AYON Desktop (OpenPype) sources.
+:: AYON_UNREAL_ROOT should point to unreal addon root
 
 SET UNREAL_ENGINE_50=%PROGRAMFILES%\Epic Games\UE_5.0
-%UNREAL_ENGINE_50%\Engine\Build\BatchFiles\RunUAT.bat BuildPlugin -plugin=%AYON_ROOT%\openpype\hosts\unreal\integration\UE_5.0\Ayon\Ayon.uplugin" -Package="%~dp0..\build\UE_5.0"
+%UNREAL_ENGINE_50%\Engine\Build\BatchFiles\RunUAT.bat BuildPlugin -plugin=%AYON_UNREAL_ROOT%\integration\UE_5.0\Ayon\Ayon.uplugin" -Package="%~dp0..\build\UE_5.0"

--- a/UE_5.1/BuildPlugin_5-1.bat
+++ b/UE_5.1/BuildPlugin_5-1.bat
@@ -1,7 +1,6 @@
 :: Set or replace UNREAL_ENGINE_51 to
 :: the location of your 5.1 installation.
-:: AYON_ROOT (formely OPENPYPE_ROOT) should point
-:: to AYON Desktop (OpenPype) sources.
+:: AYON_UNREAL_ROOT should point to unreal addon root
 
 SET UNREAL_ENGINE_51=%PROGRAMFILES%\Epic Games\UE_5.1
-%UNREAL_ENGINE_51%\Engine\Build\BatchFiles\RunUAT.bat BuildPlugin -plugin=%AYON_ROOT%\openpype\hosts\unreal\integration\UE_5.1\Ayon\Ayon.uplugin" -Package="%~dp0..\build\UE_5.1"
+%UNREAL_ENGINE_51%\Engine\Build\BatchFiles\RunUAT.bat BuildPlugin -plugin=%AYON_UNREAL_ROOT%\integration\UE_5.1\Ayon\Ayon.uplugin" -Package="%~dp0..\build\UE_5.1"

--- a/UE_5.2/BuildPlugin_5-2.bat
+++ b/UE_5.2/BuildPlugin_5-2.bat
@@ -1,7 +1,6 @@
 :: Set or replace UNREAL_ENGINE_52 to
 :: the location of your 5.2 installation.
-:: AYON_ROOT (formely OPENPYPE_ROOT) should point
-:: to AYON Desktop (OpenPype) sources.
+:: AYON_UNREAL_ROOT should point to unreal addon root
 
 SET UNREAL_ENGINE_52=%PROGRAMFILES%\Epic Games\UE_5.2
-%UNREAL_ENGINE_52%\Engine\Build\BatchFiles\RunUAT.bat BuildPlugin -plugin=%AYON_ROOT%\openpype\hosts\unreal\integration\UE_5.2\Ayon\Ayon.uplugin" -Package="%~dp0..\build\UE_5.2"
+%UNREAL_ENGINE_52%\Engine\Build\BatchFiles\RunUAT.bat BuildPlugin -plugin=%AYON_UNREAL_ROOT%\integration\UE_5.2\Ayon\Ayon.uplugin" -Package="%~dp0..\build\UE_5.2"


### PR DESCRIPTION
## Description
Replaced `AYON_ROOT` with `AYON_UNREAL_ROOT` environment variable.

## Additional information
There was used `AYON_ROOT` in believe that it will point to parent folder of unreal and openpype repository, but since it does not point there and because unreal will be moved out of openpype it was changed to use new env variable `AYON_UNREAL_ROOT`.